### PR TITLE
Tools/WorldUtils: Fix compilation.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,7 +108,7 @@ SET(PRIVATE_HEADERS
     ${CMAKE_SOURCE_DIR}/include/OpenSR/private/WidgetNode_p.h
     ${CMAKE_SOURCE_DIR}/include/OpenSR/private/RadioButton_p.h
     ${CMAKE_SOURCE_DIR}/include/OpenSR/private/RadioButtonGroup_p.h
-    ${CMAKE_SOURCE_DIR}/include/OpenSR/private/TiledLine.h
+    ${CMAKE_SOURCE_DIR}/include/OpenSR/private/TiledLine_p.h
 )
 
 INCLUDE_DIRECTORIES(

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -469,7 +469,7 @@ void Engine::init(int argc, char **argv, int w, int h, bool fullscreen)
         monoFontAA = false;
     d->monospaceFont = ResourceManager::instance().loadFont(fromLocal(monoFontStrings.at(0).c_str()), monoFontSize, monoFontAA);
 
-    setDefaultSkin(fromLocal(d->properties->get<std::string>("graphics.defaultSkin", "").c_str()));
+    setDefaultSkin(fromLocal(d->properties->get<std::string>("graphics.defaultSkin", "skin.json").c_str()));
 
     d->frames = 0;
 

--- a/tools/WorldUtils/WorldCase.cpp
+++ b/tools/WorldUtils/WorldCase.cpp
@@ -21,7 +21,7 @@
 #include "Scanner.h"
 #include "Ship.h"
 #include "ShipContext.h"
-#include "SolarSystem.h"
+#include "PlanetarySystem.h"
 #include "SpaceBase.h"
 #include "SpaceObject.h"
 #include "SystemObject.h"
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
     classes.push_back("Radar");
     classes.push_back("Scanner");
     classes.push_back("Ship");
-    classes.push_back("SolarSystem");
+    classes.push_back("PlanetarySystem");
     classes.push_back("SpaceBase");
     classes.push_back("SpaceObject");
     classes.push_back("SystemObject");

--- a/tools/WorldUtils/WorldID.cpp
+++ b/tools/WorldUtils/WorldID.cpp
@@ -21,7 +21,7 @@
 #include "Scanner.h"
 #include "Ship.h"
 #include "ShipContext.h"
-#include "SolarSystem.h"
+#include "PlanetarySystem.h"
 #include "SpaceBase.h"
 #include "SpaceObject.h"
 #include "SystemObject.h"
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
     std::cout << "Radar: " << "0x" << std::hex << (new Radar())->type() << std::endl;
     std::cout << "Scanner: " << "0x" << std::hex << (new Scanner())->type() << std::endl;
     std::cout << "Ship: " << "0x" << std::hex << (new Ship())->type() << std::endl;
-    std::cout << "SolarSystem: " << "0x" << std::hex << (new SolarSystem())->type() << std::endl;
+    std::cout << "PlanetarySystem: " << "0x" << std::hex << (new PlanetarySystem())->type() << std::endl;
     std::cout << "SpaceBase: " << "0x" << std::hex << (new SpaceBase())->type() << std::endl;
     std::cout << "SpaceObject: " << "0x" << std::hex << (new SpaceObject())->type() << std::endl;
     std::cout << "SystemObject: " << "0x" << std::hex << (new SystemObject())->type() << std::endl;


### PR DESCRIPTION
Feel free to discard 65364a5, if you already have such local changes, or if WorldUtils doesn't matter at all. In last case, please think about removing it from tree.
73ad4a4 fixes for "make install".
25be84f is fix for regression (I remember, that settings works pretty good), but I havn't catch bad commit. I found that segfault caused in CheckBox.cpp:110, because of null in d->sprite, because of null-type in style.
May be you are not affected because of line like "defaultSkin=skin.json" in OpenSR.conf.
